### PR TITLE
Boost beast controller and endpoints

### DIFF
--- a/src/boost-api/CMakeLists.txt
+++ b/src/boost-api/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(boost-api "")
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
-target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} Ws2_32.lib)
+target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} Ws2_32.lib trajectory_data_handling)
 
 target_sources(boost-api
         PRIVATE

--- a/src/boost-api/CMakeLists.txt
+++ b/src/boost-api/CMakeLists.txt
@@ -2,14 +2,13 @@ add_library(boost-api "")
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
-target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} Ws2_32.lib trajectory_data_handling)
 
 # Check if the platform is Windows
 if(WIN32)
     # Link against Ws2_32.lib on Windows
-    target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} Ws2_32.lib)
+    target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} Ws2_32.lib trajectory_data_handling)
 else()
-    target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES})
+    target_link_libraries(boost-api PRIVATE ${Boost_LIBRARIES} trajectory_data_handling)
 endif()
 
 target_sources(boost-api

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -15,12 +15,10 @@ namespace api {
     }
 
     boost::json::value get_json_from_request_body(const request<string_body> &req, response<string_body> &res) {
-        const std::string& requestBody = req.body();
-
-        boost::json::value jsonData;
+        boost::json::value jsonData{};
         try {
-            boost::json::error_code ec;
-            jsonData = boost::json::parse(requestBody, ec);
+            boost::json::error_code ec{};
+            jsonData = boost::json::parse{req.body(), ec};
             if (ec)
                 throw std::runtime_error("Failed to parse JSON: " + ec.message());
         } catch (const std::exception& e) {

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -1,7 +1,7 @@
 #include "endpoint_handlers.hpp"
 #include "boost/json/src.hpp"
 #include "boost/json/stream_parser.hpp"
-#include "boost/json/monotonic_resource.hpp"
+#include "../trajectory_data_handling/trajectory_sql.hpp"
 
 namespace api {
     using namespace boost::beast::http;

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -1,7 +1,6 @@
 #include "endpoint_handlers.hpp"
 #include <utility>
 #include <nlohmann/json.hpp>
-#include <../data/trajectory_structure.hpp>
 #include <../trajectory_data_handling/trajectory_sql.cpp>
 
 using json = nlohmann::json;
@@ -65,6 +64,33 @@ namespace api {
             }
         }
         trajectory_manager::insert_trajectories_into_trajectory_table(all_trajectories, db_table);
+    }
+
+    void handle_spatial_range_query_on_rtree_table(const request<string_body> &req, response<string_body> &res) {
+        std::string requestBody = req.body();
+
+        json jsonData;
+        try {
+            jsonData = json::parse(requestBody);
+        } catch (const std::exception& e) {
+            res.result(status::bad_request);
+            res.set(field::content_type, "text/plain");
+            res.body() = "Failed to parse JSON: " + std::string(e.what());
+            return;
+        }
+
+        trajectory_data_handling::query_purpose purpose{};
+
+        for (const auto& item : jsonData["original"].items()) {
+            purpose = item.key() == "original_trajectories" ? trajectory_data_handling::query_purpose::load_original_rtree_into_datastructure : trajectory_data_handling::query_purpose::load_simplified_rtree_into_datastructure;
+            const auto& value = item.value();
+
+            if (value.is_object() && value.contains("min") && value.contains("max")) {
+                const auto& minValue = value["min"];
+                const auto& maxValue = value["max"];
+                trajectory_manager::spatial_range_query_on_rtree_table()
+            }
+        }
     }
 
     void handle_not_found(const request<string_body> &req, response<string_body> &res) {

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -1,7 +1,5 @@
 #include "endpoint_handlers.hpp"
-#include <utility>
 #include <nlohmann/json.hpp>
-#include <../trajectory_data_handling/trajectory_sql.cpp>
 
 using json = nlohmann::json;
 

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -15,7 +15,7 @@ namespace api {
     }
 
     boost::json::value get_json_from_request_body(const request<string_body> &req, response<string_body> &res) {
-        std::string requestBody = req.body();
+        const std::string& requestBody = req.body();
 
         boost::json::value jsonData;
         try {
@@ -43,22 +43,22 @@ namespace api {
 
         try {
             auto jsonObject = jsonData.as_object();
-            for (auto it = jsonObject.begin(); it != jsonObject.end(); ++it) {
-                const auto &table_key = it->key();
-                const auto &table_value = it->value().as_object();
+            for (auto & it : jsonObject) {
+                const auto &table_key = it.key();
+                const auto &table_value = it.value().as_object();
                 db_table = table_key == "original" ? trajectory_data_handling::db_table::original_trajectories
                                                    : trajectory_data_handling::db_table::simplified_trajectories;
 
-                for (auto jt = table_value.begin(); jt != table_value.end(); ++jt) {
-                    const auto &trajectory_id = jt->key();
-                    const auto &trajectoryData = jt->value().as_object();
+                for (const auto & jt : table_value) {
+                    const auto &trajectory_id = jt.key();
+                    const auto &trajectoryData = jt.value().as_object();
 
                     data_structures::Trajectory trajectory;
                     trajectory.id = std::stoi(trajectory_id);
 
-                    for (auto kt = trajectoryData.begin(); kt != trajectoryData.end(); ++kt) {
-                        const auto &location_order = kt->key();
-                        const auto &location_data = kt->value().as_object();
+                    for (const auto & kt : trajectoryData) {
+                        const auto &location_order = kt.key();
+                        const auto &location_data = kt.value().as_object();
 
                         data_structures::Location location{};
                         location.order = std::stoi(location_order);
@@ -66,7 +66,7 @@ namespace api {
                         location.longitude = location_data.at("longitude").as_double();
                         location.latitude = location_data.at("latitude").as_double();
 
-                        trajectory.locations.emplace_back(std::move(location));
+                        trajectory.locations.emplace_back(location);
                     }
                     all_trajectories.emplace_back(std::move(trajectory));
                 }

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -1,8 +1,14 @@
 #include "endpoint_handlers.hpp"
 #include <utility>
+#include <nlohmann/json.hpp>
+#include <../data/trajectory_structure.hpp>
+#include <../trajectory_data_handling/trajectory_sql.cpp>
+
+using json = nlohmann::json;
 
 namespace api {
     using namespace boost::beast::http;
+    using namespace trajectory_data_handling;
     void handle_root(const request<string_body> &req, response<string_body> &res) {
         res.body() = "Welcome to the root endpoint!";
         res.prepare_payload();
@@ -15,6 +21,50 @@ namespace api {
         res.prepare_payload();
         res.set(field::content_type, "text/plain");
         res.result(status::ok);
+    }
+
+    void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res) {
+        std::string requestBody = req.body();
+
+        json jsonData;
+        try {
+            jsonData = json::parse(requestBody);
+        } catch (const std::exception& e) {
+            res.result(status::bad_request);
+            res.set(field::content_type, "text/plain");
+            res.body() = "Failed to parse JSON: " + std::string(e.what());
+            return;
+        }
+
+        std::vector<data_structures::Trajectory> all_trajectories{};
+        trajectory_data_handling::db_table db_table{};
+
+        for (const auto& table : jsonData.items()) {
+            const auto &table_value = table.value();
+            db_table = table.key() == "original_trajectories" ? trajectory_data_handling::db_table::original_trajectories : trajectory_data_handling::db_table::simplified_trajectories;
+
+            for(const auto &trajectory_iteration: table_value.items()) {
+                const auto &trajectoryData = trajectory_iteration.value();
+
+                data_structures::Trajectory trajectory;
+                trajectory.id = std::stoi(trajectory_iteration.key());
+
+                for (const auto &location_iteration: trajectoryData.items()) {
+                    data_structures::Location location{};
+                    const auto &order = location_iteration.key();
+                    const auto &location_data = location_iteration.value();
+
+                    location.order = std::stoi(order);
+                    location.timestamp = location_data["timestamp"];
+                    location.longitude = location_data["longitude"];
+                    location.latitude = location_data["latitude"];
+
+                    trajectory.locations.emplace_back(location);
+                }
+                all_trajectories.emplace_back(trajectory);
+            }
+        }
+        trajectory_manager::insert_trajectories_into_trajectory_table(all_trajectories, db_table);
     }
 
     void handle_not_found(const request<string_body> &req, response<string_body> &res) {

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -39,15 +39,15 @@ namespace api {
             return;
 
         std::vector<data_structures::Trajectory> all_trajectories{};
-        trajectory_data_handling::db_table db_table{};
+        db_table db_table{};
 
         try {
             auto jsonObject = jsonData.as_object();
             for (auto & it : jsonObject) {
                 const auto &table_key = it.key();
                 const auto &table_value = it.value().as_object();
-                db_table = table_key == "original" ? trajectory_data_handling::db_table::original_trajectories
-                                                   : trajectory_data_handling::db_table::simplified_trajectories;
+                db_table = table_key == "original" ? db_table::original_trajectories
+                                                   : db_table::simplified_trajectories;
 
                 for (const auto & jt : table_value) {
                     const auto &trajectory_id = jt.key();
@@ -87,11 +87,11 @@ namespace api {
         try {
             std::string db_table = jsonData.as_object().at("db_table").as_string().c_str();
 
-            trajectory_data_handling::query_purpose purpose = (db_table == "original") ?
-                                                              trajectory_data_handling::query_purpose::insert_into_original_rtree_table :
-                                                              trajectory_data_handling::query_purpose::insert_into_simplified_rtree_table;
+            query_purpose purpose = (db_table == "original") ?
+                                                              query_purpose::insert_into_original_rtree_table :
+                                                              query_purpose::insert_into_simplified_rtree_table;
 
-            trajectory_data_handling::trajectory_manager::load_trajectories_into_rtree(purpose);
+            trajectory_manager::load_trajectories_into_rtree(purpose);
         } catch (const std::exception& e) {
             res.result(status::bad_request);
             res.set(field::content_type, "text/plain");
@@ -105,12 +105,12 @@ namespace api {
             return;
 
         try {
-            trajectory_data_handling::query_purpose purpose;
+            query_purpose purpose;
 
             if (jsonData.as_object().contains("original")) {
-                purpose = trajectory_data_handling::query_purpose::load_original_rtree_into_datastructure;
+                purpose = query_purpose::load_original_rtree_into_datastructure;
             } else if (jsonData.as_object().contains("simplified")) {
-                purpose = trajectory_data_handling::query_purpose::load_simplified_rtree_into_datastructure;
+                purpose = query_purpose::load_simplified_rtree_into_datastructure;
             } else {
                 res.result(status::bad_request);
                 res.set(field::content_type, "text/plain");
@@ -137,7 +137,7 @@ namespace api {
             window.t_low = t_low;
             window.t_high = t_high;
 
-            trajectory_data_handling::trajectory_manager::spatial_range_query_on_rtree_table(purpose, window);
+            trajectory_manager::spatial_range_query_on_rtree_table(purpose, window);
         } catch (const std::exception &e) {
             res.result(status::bad_request);
             res.set(field::content_type, "text/plain");
@@ -146,7 +146,7 @@ namespace api {
     }
 
     void handle_reset_all_data(const request<string_body> &req, response<string_body> &res) {
-        trajectory_data_handling::trajectory_manager::reset_all_data();
+        trajectory_manager::reset_all_data();
     }
 
     void handle_not_found(const request<string_body> &req, response<string_body> &res) {

--- a/src/boost-api/endpoint_handlers.cpp
+++ b/src/boost-api/endpoint_handlers.cpp
@@ -1,7 +1,7 @@
 #include "endpoint_handlers.hpp"
-#include <nlohmann/json.hpp>
-
-using json = nlohmann::json;
+#include "boost/json/src.hpp"
+#include "boost/json/stream_parser.hpp"
+#include "boost/json/monotonic_resource.hpp"
 
 namespace api {
     using namespace boost::beast::http;
@@ -14,115 +14,135 @@ namespace api {
         res.result(status::ok);
     }
 
-    json get_json_from_request_body(const request<string_body> &req,  response<string_body> &res) {
+    boost::json::value get_json_from_request_body(const request<string_body> &req, response<string_body> &res) {
         std::string requestBody = req.body();
 
-        json jsonData{};
+        boost::json::value jsonData;
         try {
-            jsonData = json::parse(requestBody);
+            boost::json::error_code ec;
+            jsonData = boost::json::parse(requestBody, ec);
+            if (ec)
+                throw std::runtime_error("Failed to parse JSON: " + ec.message());
         } catch (const std::exception& e) {
             res.result(status::bad_request);
             res.set(field::content_type, "text/plain");
             res.body() = "Failed to parse JSON: " + std::string(e.what());
+            return {};
         }
 
         return jsonData;
     }
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res) {
-        json jsonData = get_json_from_request_body(req, res);
-        if (jsonData.empty())
+        boost::json::value jsonData = get_json_from_request_body(req, res);
+        if (jsonData.is_null())
             return;
 
         std::vector<data_structures::Trajectory> all_trajectories{};
         trajectory_data_handling::db_table db_table{};
 
-        for (const auto& table : jsonData.items()) {
-            const auto &table_value = table.value();
-            db_table = table.key() == "original" ? trajectory_data_handling::db_table::original_trajectories : trajectory_data_handling::db_table::simplified_trajectories;
+        try {
+            auto jsonObject = jsonData.as_object();
+            for (auto it = jsonObject.begin(); it != jsonObject.end(); ++it) {
+                const auto &table_key = it->key();
+                const auto &table_value = it->value().as_object();
+                db_table = table_key == "original" ? trajectory_data_handling::db_table::original_trajectories
+                                                   : trajectory_data_handling::db_table::simplified_trajectories;
 
-            for(const auto &trajectory_iteration: table_value.items()) {
-                const auto &trajectoryData = trajectory_iteration.value();
+                for (auto jt = table_value.begin(); jt != table_value.end(); ++jt) {
+                    const auto &trajectory_id = jt->key();
+                    const auto &trajectoryData = jt->value().as_object();
 
-                data_structures::Trajectory trajectory;
-                trajectory.id = std::stoi(trajectory_iteration.key());
+                    data_structures::Trajectory trajectory;
+                    trajectory.id = std::stoi(trajectory_id);
 
-                for (const auto &location_iteration: trajectoryData.items()) {
-                    data_structures::Location location{};
-                    const auto &order = location_iteration.key();
-                    const auto &location_data = location_iteration.value();
+                    for (auto kt = trajectoryData.begin(); kt != trajectoryData.end(); ++kt) {
+                        const auto &location_order = kt->key();
+                        const auto &location_data = kt->value().as_object();
 
-                    location.order = std::stoi(order);
-                    location.timestamp = location_data["timestamp"];
-                    location.longitude = location_data["longitude"];
-                    location.latitude = location_data["latitude"];
+                        data_structures::Location location{};
+                        location.order = std::stoi(location_order);
+                        location.timestamp = location_data.at("timestamp").as_double();
+                        location.longitude = location_data.at("longitude").as_double();
+                        location.latitude = location_data.at("latitude").as_double();
 
-                    trajectory.locations.emplace_back(location);
+                        trajectory.locations.emplace_back(std::move(location));
+                    }
+                    all_trajectories.emplace_back(std::move(trajectory));
                 }
-                all_trajectories.emplace_back(trajectory);
             }
+            trajectory_manager::insert_trajectories_into_trajectory_table(all_trajectories, db_table);
+        } catch (const std::exception &e) {
+            res.result(status::bad_request);
+            res.set(field::content_type, "text/plain");
+            res.body() = "Error processing JSON data: " + std::string(e.what());
         }
-        trajectory_manager::insert_trajectories_into_trajectory_table(all_trajectories, db_table);
     }
 
     void handle_load_trajectories_into_rtree(const request<string_body> &req, response<string_body> &res) {
-        json jsonData = get_json_from_request_body(req, res);
-        if (jsonData.empty())
+        boost::json::value jsonData = get_json_from_request_body(req, res);
+        if (jsonData.is_null())
             return;
 
-        std::string db_table;
         try {
-            db_table = jsonData.at("db_table").get<std::string>();
+            std::string db_table = jsonData.as_object().at("db_table").as_string().c_str();
+
+            trajectory_data_handling::query_purpose purpose = (db_table == "original") ?
+                                                              trajectory_data_handling::query_purpose::insert_into_original_rtree_table :
+                                                              trajectory_data_handling::query_purpose::insert_into_simplified_rtree_table;
+
+            trajectory_data_handling::trajectory_manager::load_trajectories_into_rtree(purpose);
         } catch (const std::exception& e) {
             res.result(status::bad_request);
             res.set(field::content_type, "text/plain");
             res.body() = "Failed to read 'db_table' value from JSON: " + std::string(e.what());
-            return;
         }
-
-        trajectory_data_handling::query_purpose purpose = db_table == "original" ? trajectory_data_handling::query_purpose::insert_into_original_rtree_table : trajectory_data_handling::query_purpose::insert_into_simplified_rtree_table;
-
-        trajectory_data_handling::trajectory_manager::load_trajectories_into_rtree(purpose);
     }
 
     void handle_spatial_range_query_on_rtree_table(const request<string_body> &req, response<string_body> &res) {
-        json jsonData = get_json_from_request_body(req, res);
-        if (jsonData.empty())
+        boost::json::value jsonData = get_json_from_request_body(req, res);
+        if (jsonData.is_null())
             return;
 
-        trajectory_data_handling::query_purpose purpose;
-        if (jsonData.contains("original")) {
-            purpose = trajectory_data_handling::query_purpose::load_original_rtree_into_datastructure;
-        } else if (jsonData.contains("simplified")) {
-            purpose = trajectory_data_handling::query_purpose::load_simplified_rtree_into_datastructure;
-        } else {
+        try {
+            trajectory_data_handling::query_purpose purpose;
+
+            if (jsonData.as_object().contains("original")) {
+                purpose = trajectory_data_handling::query_purpose::load_original_rtree_into_datastructure;
+            } else if (jsonData.as_object().contains("simplified")) {
+                purpose = trajectory_data_handling::query_purpose::load_simplified_rtree_into_datastructure;
+            } else {
+                res.result(status::bad_request);
+                res.set(field::content_type, "text/plain");
+                res.body() = "Invalid JSON format: missing 'original' or 'simplified' key";
+                return;
+            }
+
+            boost::json::object originalData = jsonData.as_object().at("original").as_object();
+
+            double x_low = originalData.at("longitudeRange").as_object().at("min").as_double();
+            double x_high = originalData.at("longitudeRange").as_object().at("max").as_double();
+
+            double y_low = originalData.at("latitudeRange").as_object().at("min").as_double();
+            double y_high = originalData.at("latitudeRange").as_object().at("max").as_double();
+
+            long double t_low = originalData.at("timestampRange").as_object().at("min").as_double();
+            long double t_high = originalData.at("timestampRange").as_object().at("max").as_double();
+
+            spatial_queries::Range_Query::Window window{};
+            window.x_low = x_low;
+            window.x_high = x_high;
+            window.y_low = y_low;
+            window.y_high = y_high;
+            window.t_low = t_low;
+            window.t_high = t_high;
+
+            trajectory_data_handling::trajectory_manager::spatial_range_query_on_rtree_table(purpose, window);
+        } catch (const std::exception &e) {
             res.result(status::bad_request);
             res.set(field::content_type, "text/plain");
-            res.body() = "Invalid JSON format: missing 'original' or 'simplified' key";
-            return;
+            res.body() = "Error processing JSON data: " + std::string(e.what());
         }
-
-        auto& longitudeRange = jsonData["original"]["longitudeRange"];
-        double x_low = longitudeRange["min"];
-        double x_high = longitudeRange["max"];
-
-        auto& latitudeRange = jsonData["original"]["latitudeRange"];
-        double y_low = latitudeRange["min"];
-        double y_high = latitudeRange["max"];
-
-        auto& timestampRange = jsonData["original"]["timestampRange"];
-        long double t_low = timestampRange["min"];
-        long double t_high = timestampRange["max"];
-
-        spatial_queries::Range_Query::Window window{};
-        window.x_low = x_low;
-        window.x_high = x_high;
-        window.y_low = y_low;
-        window.y_high = y_high;
-        window.t_low = t_low;
-        window.t_high = t_high;
-
-        trajectory_data_handling::trajectory_manager::spatial_range_query_on_rtree_table(purpose, window);
     }
 
     void handle_reset_all_data(const request<string_body> &req, response<string_body> &res) {

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -3,11 +3,10 @@
 #include <boost/beast/http.hpp>
 #include <map>
 #include <functional>
-#include "../trajectory_data_handling/trajectory_sql.hpp"
 
 namespace api {
     using namespace boost::beast::http;
-    
+
     using RequestHandler = std::function<void(const request<string_body> &, response<string_body> &)>;
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -3,11 +3,15 @@
 #include <boost/beast/http.hpp>
 #include <map>
 #include <functional>
+#include "../trajectory_data_handling/trajectory_sql.hpp"
 
 namespace api {
     using namespace boost::beast::http;
+
     // Define a handler type for request handling functions
     using RequestHandler = std::function<void(const request<string_body> &, response<string_body> &)>;
+
+    void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);
 
     void handle_root(const request<string_body> &req, response<string_body> &res);
 

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -13,6 +13,8 @@ namespace api {
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);
 
+    void handle_spatial_range_query_on_rtree_table(const request<string_body> &req, response<string_body> &res);
+
     void handle_root(const request<string_body> &req, response<string_body> &res);
 
     void handle_hello(const request<string_body> &req, response<string_body> &res);

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -7,8 +7,7 @@
 
 namespace api {
     using namespace boost::beast::http;
-
-    // Define a handler type for request handling functions
+    
     using RequestHandler = std::function<void(const request<string_body> &, response<string_body> &)>;
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);
@@ -20,8 +19,6 @@ namespace api {
     void handle_reset_all_data(const request<string_body> &req, response<string_body> &res);
 
     void handle_root(const request<string_body> &req, response<string_body> &res);
-
-    void handle_hello(const request<string_body> &req, response<string_body> &res);
 
     void handle_not_found(const request<string_body> &req, response<string_body> &res);
 }

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -11,11 +11,7 @@ namespace api {
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);
 
-    void handle_load_trajectories_into_rtree(const request<string_body> &req, response<string_body> &res);
-
     void handle_spatial_range_query_on_rtree_table(const request<string_body> &req, response<string_body> &res);
-
-    void handle_reset_all_data(const request<string_body> &req, response<string_body> &res);
 
     void handle_root(const request<string_body> &req, response<string_body> &res);
 

--- a/src/boost-api/endpoint_handlers.hpp
+++ b/src/boost-api/endpoint_handlers.hpp
@@ -13,7 +13,11 @@ namespace api {
 
     void handle_insert_trajectories_into_trajectory_table(const request<string_body> &req, response<string_body> &res);
 
+    void handle_load_trajectories_into_rtree(const request<string_body> &req, response<string_body> &res);
+
     void handle_spatial_range_query_on_rtree_table(const request<string_body> &req, response<string_body> &res);
+
+    void handle_reset_all_data(const request<string_body> &req, response<string_body> &res);
 
     void handle_root(const request<string_body> &req, response<string_body> &res);
 

--- a/src/data/trajectory_structure.hpp
+++ b/src/data/trajectory_structure.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+
 namespace data_structures {
 
     struct Location {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,7 @@
 
 int main(int argc, char* argv[]) {
     for(int i = 1; i < argc; i++) {
-        std::string arg = argv[i];
-        if(arg == "--reset") {
+        if(argv[i] == "--reset") {
             trajectory_data_handling::trajectory_manager::reset_all_data();
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,6 +75,8 @@ int main() {
     endpoints["/hello"] = api::handle_hello;
     endpoints["/insert"] = api::handle_insert_trajectories_into_trajectory_table;
     endpoints["/query"] = api::handle_spatial_range_query_on_rtree_table;
+    endpoints["/rtree"] = api::handle_load_trajectories_into_rtree;
+    endpoints["/reset"] = api::handle_reset_all_data;
 
     // Set up the io_context
     boost::asio::io_context io_context{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,19 @@
 #include "endpoint_handlers.hpp"
 
 int main(int argc, char* argv[]) {
+    for(int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if(arg == "--reset") {
+            trajectory_data_handling::trajectory_manager::reset_all_data();
+        }
+    }
+
     trajectory_data_handling::file_manager file_manager{};
     auto original_trajectories = std::make_shared<std::vector<data_structures::Trajectory>>();
     trajectory_data_handling::query_handler::original_trajectories = original_trajectories;
 
     auto simplified_trajectories = std::make_shared<std::vector<data_structures::Trajectory>>();
     trajectory_data_handling::query_handler::simplified_trajectories = simplified_trajectories;
-
 
 //    trajectory_data_handling::trajectory_manager.reset_all_data();
 //    trajectory_data_handling::trajectory_managercreate_database();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ int main() {
     endpoints["/"] = api::handle_root;
     endpoints["/hello"] = api::handle_hello;
     endpoints["/insert"] = api::handle_insert_trajectories_into_trajectory_table;
+    endpoints["/query"] = api::handle_spatial_range_query_on_rtree_table;
 
     // Set up the io_context
     boost::asio::io_context io_context{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,6 @@ int main() {
     std::map<std::string, api::RequestHandler> endpoints;
 
     endpoints["/"] = api::handle_root;
-    endpoints["/hello"] = api::handle_hello;
     endpoints["/insert"] = api::handle_insert_trajectories_into_trajectory_table;
     endpoints["/query"] = api::handle_spatial_range_query_on_rtree_table;
     endpoints["/rtree"] = api::handle_load_trajectories_into_rtree;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include "start-api.hpp"
 #include "endpoint_handlers.hpp"
 
-int main() {
+int main(int argc, char* argv[]) {
     trajectory_data_handling::file_manager file_manager{};
     auto original_trajectories = std::make_shared<std::vector<data_structures::Trajectory>>();
     trajectory_data_handling::query_handler::original_trajectories = original_trajectories;
@@ -68,8 +68,6 @@ int main() {
     endpoints["/"] = api::handle_root;
     endpoints["/insert"] = api::handle_insert_trajectories_into_trajectory_table;
     endpoints["/query"] = api::handle_spatial_range_query_on_rtree_table;
-    endpoints["/rtree"] = api::handle_load_trajectories_into_rtree;
-    endpoints["/reset"] = api::handle_reset_all_data;
 
     // Set up the io_context
     boost::asio::io_context io_context{};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,15 +63,17 @@ int main() {
     auto trace_q = trace_q::TRACE_Q{2, 0.1, 3, 1.3, 0.2};
     auto result = trace_q.simplify(t, 0.99);
 
-    for (int i = 0; i < result.locations.size(); ++i) {
-        std::cout << "loc" << i + 1 << ", longitude: " << result.locations[i].longitude
-        << ", latitude: " << result.locations[i].latitude << ", t: " << result.locations[i].timestamp << '\n';
-    }
+//    for (int i = 0; i < result.locations.size(); ++i) {
+//        std::cout << "loc" << i + 1 << ", longitude: " << result.locations[i].longitude
+//        << ", latitude: " << result.locations[i].latitude << ", t: " << result.locations[i].timestamp << '\n';
+//    }
 
     // Define and populate endpoints map
     std::map<std::string, api::RequestHandler> endpoints;
+
     endpoints["/"] = api::handle_root;
     endpoints["/hello"] = api::handle_hello;
+    endpoints["/insert"] = api::handle_insert_trajectories_into_trajectory_table;
 
     // Set up the io_context
     boost::asio::io_context io_context{};

--- a/src/trajectory_data_handling/trajectory_sql.cpp
+++ b/src/trajectory_data_handling/trajectory_sql.cpp
@@ -160,9 +160,10 @@ namespace trajectory_data_handling {
         trajectory_data_handling::query_handler::run_sql("DROP TABLE trajectory_information", query_purpose::reset_database);
         trajectory_data_handling::query_handler::run_sql("DROP TABLE simplified_trajectory_information", query_purpose::reset_database);
         trajectory_data_handling::query_handler::run_sql("DROP TABLE trajectory_rtree", query_purpose::reset_database);
-        trajectory_data_handling::query_handler::run_sql("DROP TABLE trajectory_rtree_rowid", query_purpose::reset_database);
-        trajectory_data_handling::query_handler::run_sql("DROP TABLE trajectory_rtree_parent", query_purpose::reset_database);
-        trajectory_data_handling::query_handler::run_sql("DROP TABLE trajectory_rtree_node", query_purpose::reset_database);
+        trajectory_data_handling::query_handler::run_sql("DROP TABLE simplified_trajectory_rtree", query_purpose::reset_database);
+
+        create_database();
+        create_rtree_table();
     }
 }
 

--- a/src/trajectory_data_handling/trajectory_sql.hpp
+++ b/src/trajectory_data_handling/trajectory_sql.hpp
@@ -14,7 +14,7 @@ namespace trajectory_data_handling {
         simplified_trajectories
     };
 
-    class trajectory_manager {
+    struct trajectory_manager {
     public:
         static void load_trajectories_into_rtree(query_purpose rtree_table);
         static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> const& all_trajectories, db_table table);

--- a/src/trajectory_data_handling/trajectory_sql.hpp
+++ b/src/trajectory_data_handling/trajectory_sql.hpp
@@ -16,14 +16,14 @@ namespace trajectory_data_handling {
 
     class trajectory_manager {
     public:
-        void load_trajectories_into_rtree(query_purpose rtree_table);
-        void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> &all_trajectories, db_table table);
-        void spatial_range_query_on_rtree_table(query_purpose purpose, std::tuple<float, float> longitudeRange, std::tuple<float, float> latitudeRange, std::tuple<float, float> timestampRange);
-        void load_database_into_datastructure(query_purpose purpose, std::vector<std::string> const& id);
-        void print_trajectories(std::vector<data_structures::Trajectory> &all_trajectories);
-        void create_database();
-        void create_rtree_table();
-        void reset_all_data();
+        static void load_trajectories_into_rtree(query_purpose rtree_table);
+        static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> &all_trajectories, db_table table);
+        static void spatial_range_query_on_rtree_table(query_purpose purpose, std::tuple<float, float> longitudeRange, std::tuple<float, float> latitudeRange, std::tuple<float, float> timestampRange);
+        static void load_database_into_datastructure(query_purpose purpose, std::vector<std::string> const& id);
+        static void print_trajectories(std::vector<data_structures::Trajectory> &all_trajectories);
+        static void create_database();
+        static void create_rtree_table();
+        static void reset_all_data();
     };
 }
 

--- a/src/trajectory_data_handling/trajectory_sql.hpp
+++ b/src/trajectory_data_handling/trajectory_sql.hpp
@@ -6,6 +6,7 @@
 #include <tuple>
 #include "../data/trajectory_structure.hpp"
 #include "sqlite_querying.hpp"
+#include "../querying/Range_Query.hpp"
 
 
 namespace trajectory_data_handling {
@@ -18,7 +19,8 @@ namespace trajectory_data_handling {
     public:
         static void load_trajectories_into_rtree(query_purpose rtree_table);
         static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> &all_trajectories, db_table table);
-        static void spatial_range_query_on_rtree_table(query_purpose purpose, std::tuple<float, float> longitudeRange, std::tuple<float, float> latitudeRange, std::tuple<float, float> timestampRange);
+        static void remove_from_trajectories(std::shared_ptr<std::vector<data_structures::Trajectory>>& trajectories, spatial_queries::Range_Query::Window window);
+        static void spatial_range_query_on_rtree_table(query_purpose purpose, spatial_queries::Range_Query::Window window);
         static void load_database_into_datastructure(query_purpose purpose, std::vector<std::string> const& id);
         static void print_trajectories(std::vector<data_structures::Trajectory> &all_trajectories);
         static void create_database();

--- a/src/trajectory_data_handling/trajectory_sql.hpp
+++ b/src/trajectory_data_handling/trajectory_sql.hpp
@@ -17,7 +17,7 @@ namespace trajectory_data_handling {
     class trajectory_manager {
     public:
         static void load_trajectories_into_rtree(query_purpose rtree_table);
-        static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> &all_trajectories, db_table table);
+        static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> const& all_trajectories, db_table table);
         static void remove_from_trajectories(std::shared_ptr<std::vector<data_structures::Trajectory>>& trajectories, spatial_queries::Range_Query::Window window);
         static void spatial_range_query_on_rtree_table(query_purpose purpose, spatial_queries::Range_Query::Window window);
         static void load_database_into_datastructure(query_purpose purpose, std::vector<std::string> const& id);

--- a/src/trajectory_data_handling/trajectory_sql.hpp
+++ b/src/trajectory_data_handling/trajectory_sql.hpp
@@ -15,7 +15,6 @@ namespace trajectory_data_handling {
     };
 
     struct trajectory_manager {
-    public:
         static void load_trajectories_into_rtree(query_purpose rtree_table);
         static void insert_trajectories_into_trajectory_table(std::vector<data_structures::Trajectory> const& all_trajectories, db_table table);
         static void remove_from_trajectories(std::shared_ptr<std::vector<data_structures::Trajectory>>& trajectories, spatial_queries::Range_Query::Window window);


### PR DESCRIPTION
Added the following endpoints:

1. /insert: Inserts a JSON into the trajectory table for both original and simplified
2. /query: Spatial range queries on the rtree tables for both original and simplified
3. /rtree: Loads both original and simplified data into the rtree
4. /reset: Simply just resets all data

