### PR TITLE
CORS headers and minor tweak to Start_API

### DIFF
--- a/src/boost-api/Endpoint_Handlers.cpp
+++ b/src/boost-api/Endpoint_Handlers.cpp
@@ -8,6 +8,19 @@ namespace api {
     using namespace boost::beast::http;
     using namespace trajectory_data_handling;
 
+    void add_cors_headers(response<string_body> &res) {
+        res.set(field::access_control_allow_origin, "*");  // You can replace * with the specific origin you want to allow
+        res.set(field::access_control_allow_methods, "GET, POST, PUT, DELETE, OPTIONS");
+        res.set(field::access_control_allow_headers, "Content-Type, Authorization");
+    }
+
+    void handle_options(const request<string_body> &req, response<string_body> &res) {
+        add_cors_headers(res);
+        res.result(status::ok);
+        res.set(field::content_type, "text/plain");
+        res.body() = "";
+    }
+
     void handle_root(const request<string_body> &req, response<string_body> &res) {
         res.body() = "Welcome to the root endpoint!";
         res.prepare_payload();
@@ -33,6 +46,12 @@ namespace api {
     }
 
     void handle_insert_trajectory_into_trajectory_table(const request<string_body> &req, response<string_body> &res) {
+        if (req.method() == verb::options) {
+            handle_options(req, res);
+            return;
+        }
+
+        add_cors_headers(res);
         boost::json::value jsonData = get_json_from_request_body(req, res);
         if (jsonData.is_null()) {
             return;

--- a/src/boost-api/Start_API.cpp
+++ b/src/boost-api/Start_API.cpp
@@ -15,7 +15,7 @@ namespace api {
             acceptor.accept(socket);
 
             // Declare the error_code variable here
-            boost::system::error_code ec;
+            boost::system::error_code ec{};
 
             while (true) {
                 // Read the HTTP request


### PR DESCRIPTION
These changes include:

- CORS headers so the front-end can send requests to the API
- A tweak to Start_API that addresses the following problem: Whenever a request was sent from the front-end, the connection would not properly close which lead to the socket reading an "empty request", which would cause the program to crash since it tried to read from an empty stream (the empty request). 