### PR TITLE
TRACE-Q run-method which runs the algorithm in batches concurrently

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,42 +14,13 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // TRACE-Q test
     trajectory_data_handling::Trajectory_Manager::reset_all_data();
     trajectory_data_handling::File_Manager::load_tdrive_dataset();
 
     auto trace_q = trace_q::TRACE_Q{2, 0.95, 0.1, 0.1, 3, 1.3, 0.2, 0.03, 10};
     trace_q.run();
-
-    /*trajectory_data_handling::Trajectory_Manager::db_knn_query(trajectory_data_handling::db_table::original_trajectories, 2, spatial_queries::KNN_Query::KNN_Origin{200, 200, trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:36:08"), trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:56:08")});
-    trajectory_data_handling::Trajectory_Manager::db_range_query(trajectory_data_handling::db_table::original_trajectories, spatial_queries::Range_Query::Window{115, 117, 38, 40, trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:36:08"), trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:56:08")});
-
-    data_structures::Trajectory t {};
-    t.locations.emplace_back(data_structures::Location(1, 0, 1, 2));
-    t.locations.emplace_back(data_structures::Location(2, 1, 4, 2));
-    t.locations.emplace_back(data_structures::Location(3, 4, 7, 4));
-    t.locations.emplace_back(data_structures::Location(4, 12, 17, 9));
-    t.locations.emplace_back(data_structures::Location(5,15, 26, 12));
-    t.locations.emplace_back(data_structures::Location(6, 18, 32, 5));
-    t.locations.emplace_back(data_structures::Location(7,22, 69, 3));
-    t.locations.emplace_back(data_structures::Location(8, 23, 110, 21));
-    t.locations.emplace_back(data_structures::Location(9, 24, 112, 23));
-    t.locations.emplace_back(data_structures::Location(10, 28, 143, 28));
-    t.locations.emplace_back(data_structures::Location(11, 30, 145, 31));
-    t.locations.emplace_back(data_structures::Location(12, 35, 156, 56));
-    t.locations.emplace_back(data_structures::Location(13, 37, 169, 61));
-    t.locations.emplace_back(data_structures::Location(14,41, 173, 66));
-    t.locations.emplace_back(data_structures::Location(15, 44, 182, 69));
-    t.locations.emplace_back(data_structures::Location(16,50, 243, 98));
-    t.locations.emplace_back(data_structures::Location(17, 53, 277, 143));
-    t.locations.emplace_back(data_structures::Location(18, 60, 300, 200));
-
-    auto trace_q = trace_q::TRACE_Q{2, 0.1, 0.1, 3, 1.3, 0.2, 0.2, 10};
-    auto result = trace_q.simplify(t, 0.99);
-
-    for (int i = 0; i < result.locations.size(); ++i) {
-        std::cout << "loc" << i + 1 << ", longitude: " << result.locations[i].longitude
-        << ", latitude: " << result.locations[i].latitude << ", t: " << result.locations[i].timestamp << '\n';
-    }
+    
 
     // Define and populate endpoints map
     std::map<std::string, api::RequestHandler> endpoints;
@@ -63,7 +34,7 @@ int main(int argc, char* argv[]) {
     // Create and bind an acceptor to listen for incoming connections
     boost::asio::ip::tcp::acceptor acceptor(io_context, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 8080));
     // Run the server
-    api::run(acceptor, endpoints);*/
+    api::run(acceptor, endpoints);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,11 +17,8 @@ int main(int argc, char* argv[]) {
     trajectory_data_handling::Trajectory_Manager::reset_all_data();
     trajectory_data_handling::File_Manager::load_tdrive_dataset();
 
-    for (auto trajectories = trajectory_data_handling::Trajectory_Manager::load_into_data_structure(trajectory_data_handling::db_table::original_trajectories); auto const& t : trajectories) {
-        auto trace_q = trace_q::TRACE_Q{2, 0.1, 0.1, 3, 1.3, 0.2, 0.2, 10};
-        auto result = trace_q.simplify(t, 0.99);
-        trajectory_data_handling::Trajectory_Manager::insert_trajectory(result, trajectory_data_handling::db_table::simplified_trajectories);
-    }
+    auto trace_q = trace_q::TRACE_Q{2, 0.95, 0.1, 0.1, 3, 1.3, 0.2, 0.03, 10};
+    trace_q.run();
 
     /*trajectory_data_handling::Trajectory_Manager::db_knn_query(trajectory_data_handling::db_table::original_trajectories, 2, spatial_queries::KNN_Query::KNN_Origin{200, 200, trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:36:08"), trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:56:08")});
     trajectory_data_handling::Trajectory_Manager::db_range_query(trajectory_data_handling::db_table::original_trajectories, spatial_queries::Range_Query::Window{115, 117, 38, 40, trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:36:08"), trajectory_data_handling::File_Manager::string_to_time("2008-02-02 15:56:08")});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
 
     auto trace_q = trace_q::TRACE_Q{2, 0.95, 0.1, 0.1, 3, 1.3, 0.2, 0.03, 10};
     trace_q.run();
-    
+
 
     // Define and populate endpoints map
     std::map<std::string, api::RequestHandler> endpoints;

--- a/src/simp-algorithms/MRPA.cpp
+++ b/src/simp-algorithms/MRPA.cpp
@@ -59,7 +59,7 @@ namespace simp_algorithms {
                         (resolution - 1) * j + 1));
 
                 if (j == resolution - 1 && range_end < trajectory.size()) {
-                    throw std::range_error("Last range_end variable is not equal to size of trajectory");
+                    range_end = static_cast<int>(trajectory.size());
                 }
 
                 error_tolerance += error_SED_sum(trajectory, range_start, range_end);
@@ -96,16 +96,15 @@ namespace simp_algorithms {
         Trajectory res {};
 
         for (int k = i + 1; k < j; ++k) {
-            auto x = trajectory[i].longitude +
+            auto x = static_cast<double>(trajectory[i].longitude +
                      (static_cast<long double>(trajectory[k].timestamp - trajectory[i].timestamp) /
                      static_cast<long double>((trajectory[j].timestamp - trajectory[i].timestamp))) *
-                     (trajectory[j].longitude - trajectory[i].longitude);
-            auto y = trajectory[i].latitude +
+                     (trajectory[j].longitude - trajectory[i].longitude));
+            auto y = static_cast<double>(trajectory[i].latitude +
                      (static_cast<long double>(trajectory[k].timestamp - trajectory[i].timestamp) /
                      static_cast<long double>((trajectory[j].timestamp - trajectory[i].timestamp))) *
-                     (trajectory[j].latitude - trajectory[i].latitude);
-            auto point = Location (trajectory[k].order, trajectory[k].timestamp, x, y);
-            res.locations.emplace_back(point);
+                     (trajectory[j].latitude - trajectory[i].latitude));
+            res.locations.emplace_back(trajectory[k].order, trajectory[k].timestamp, x, y);
         }
 
         return res;

--- a/src/simp-algorithms/TRACE_Q.cpp
+++ b/src/simp-algorithms/TRACE_Q.cpp
@@ -234,8 +234,8 @@ namespace trace_q {
             futures.emplace_back(std::async(std::launch::async, [this](unsigned int t_id){
                 auto original_trajectory =
                         Trajectory_Manager::load_into_data_structure(db_table::original_trajectories,
-                                                                     std::vector<unsigned int>{t_id});
-                auto simplified_trajectory = simplify(original_trajectory.front());
+                                                                     std::vector<unsigned int>{t_id}).front();
+                auto simplified_trajectory = simplify(original_trajectory);
                 Trajectory_Manager::insert_trajectory(simplified_trajectory,
                                                       db_table::simplified_trajectories);
                 return true;

--- a/src/simp-algorithms/TRACE_Q.cpp
+++ b/src/simp-algorithms/TRACE_Q.cpp
@@ -218,7 +218,7 @@ namespace trace_q {
 
         while(counter < ids.size()) {
             for (int i = 0; i < max_trajectories_in_batch && counter < ids.size(); i++, counter++) {
-                    working_ids.push_back(ids[counter]);
+                working_ids.push_back(ids[counter]);
             }
             batch_job(working_ids);
             working_ids.clear();

--- a/src/trajectory_data_handling/Trajectory_Manager.cpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.cpp
@@ -20,11 +20,26 @@ namespace trajectory_data_handling {
                     << std::to_string(trajectory[0].timestamp) << ");";
 
         txn.exec0(first_query.str());
-        for (int i = 1; i < trajectory.size(); i++) {
-            if(!(trajectory[i] == trajectory[i-1])) {
+
+        if (table == db_table::original_trajectories) {
+            for (int i = 1; i < trajectory.size(); i++) {
+                if (!(trajectory[i] == trajectory[i - 1])) {
+                    std::stringstream query{};
+                    query << "INSERT INTO " << table_name << "(trajectory_id, coordinates, time) " << " VALUES("
+                          << trajectory.id << ", point(" << std::to_string(trajectory[i].longitude) << ", "
+                          << std::to_string(trajectory[i].latitude) << "), "
+                          << std::to_string(trajectory[i].timestamp) << ");";
+
+                    txn.exec0(query.str());
+                }
+            }
+        }
+        else if (table == db_table::simplified_trajectories) {
+            for (int i = 1; i < trajectory.size(); i++) {
                 std::stringstream query{};
                 query << "INSERT INTO " << table_name << "(trajectory_id, coordinates, time) " << " VALUES("
-                      << trajectory.id << ", point(" << std::to_string(trajectory[i].longitude) << ", " << std::to_string(trajectory[i].latitude) << "), "
+                      << trajectory.id << ", point(" << std::to_string(trajectory[i].longitude) << ", "
+                      << std::to_string(trajectory[i].latitude) << "), "
                       << std::to_string(trajectory[i].timestamp) << ");";
 
                 txn.exec0(query.str());
@@ -180,7 +195,7 @@ namespace trajectory_data_handling {
         }
     }
 
-    std::vector<int> Trajectory_Manager::db_get_all_trajectory_ids(trajectory_data_handling::db_table table) {
+    std::vector<unsigned int> Trajectory_Manager::db_get_all_trajectory_ids(trajectory_data_handling::db_table table) {
         auto table_name = get_table_name(table);
 
         std::stringstream query{};
@@ -193,7 +208,7 @@ namespace trajectory_data_handling {
         auto query_result = txn.query<int>(query.str());
         txn.commit();
 
-        auto result = std::vector<int>{};
+        auto result = std::vector<unsigned int>{};
         for (auto& [id] : query_result) {
             result.emplace_back(id);
         }

--- a/src/trajectory_data_handling/Trajectory_Manager.cpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.cpp
@@ -116,7 +116,6 @@ namespace trajectory_data_handling {
         return data_structures::Location{order, time, std::stod(lon_str), std::stod(lat_str)};
     }
 
-
     std::vector<data_structures::Trajectory> Trajectory_Manager::db_range_query(db_table table, spatial_queries::Range_Query::Window const& window) {
         auto table_name = get_table_name(table);
 
@@ -125,25 +124,6 @@ namespace trajectory_data_handling {
         return load_into_data_structure(table, query_results);
     }
 
-    std::vector<data_structures::Trajectory> Trajectory_Manager::db_knn_query(
-            db_table table, int k, spatial_queries::KNN_Query::KNN_Origin const& query_origin) {
-        auto table_name = get_table_name(table);
-
-        auto query_results = spatial_queries::KNN_Query::get_ids_from_knn(table_name, k, query_origin);
-
-        std::vector<unsigned int> result_ids{};
-
-        for(const auto& query_result : query_results) {
-            result_ids.push_back(query_result.id);
-        }
-
-        return load_into_data_structure(table, result_ids);
-    }
-
-    /**
-     * Helper function that prints a list of trajectories.
-     * @param all_trajectories
-     */
     void Trajectory_Manager::print_trajectories(std::vector<data_structures::Trajectory> const& all_trajectories) {
         for (const auto & trajectory : all_trajectories) {
             std::cout << "id: " << trajectory.id << std::endl;

--- a/src/trajectory_data_handling/Trajectory_Manager.cpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.cpp
@@ -179,6 +179,27 @@ namespace trajectory_data_handling {
                 throw std::invalid_argument("Error in switch statement in get_table_name");
         }
     }
+
+    std::vector<int> Trajectory_Manager::db_get_all_trajectory_ids(trajectory_data_handling::db_table table) {
+        auto table_name = get_table_name(table);
+
+        std::stringstream query{};
+
+        query << "SELECT DISTINCT trajectory_id FROM " << table_name << ";";
+
+        pqxx::connection c{connection_string};
+        pqxx::work txn{c};
+
+        auto query_result = txn.query<int>(query.str());
+        txn.commit();
+
+        auto result = std::vector<int>{};
+        for (auto& [id] : query_result) {
+            result.emplace_back(id);
+        }
+
+        return result;
+    }
 }
 
 

--- a/src/trajectory_data_handling/Trajectory_Manager.hpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.hpp
@@ -37,16 +37,6 @@ namespace trajectory_data_handling {
                 db_table table, spatial_queries::Range_Query::Window const& window);
 
         /**
-         * Performs a K-Nearest-Neighbour query on the given database given a
-         * @param table The table to query.
-         * @param k The amount of nearest neighbours to return.
-         * @param query_origin The origin point from where the nearest neighbours are discovered using euclidean distance.
-         * @return A list of trajectories corresponding to the K-Nearest-Neighbours from the origin point.
-         */
-        static std::vector<data_structures::Trajectory> db_knn_query(
-                db_table table, int k, spatial_queries::KNN_Query::KNN_Origin const& query_origin);
-
-        /**
          * Loads a vector of trajectories from the database. If a list of ids are not given, all trajectories are loaded.
          * @param table The table to load trajectories from.
          * @param ids Vector of the ids of trajectories to load from the given table.

--- a/src/trajectory_data_handling/Trajectory_Manager.hpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.hpp
@@ -76,7 +76,7 @@ namespace trajectory_data_handling {
          * @param table The database table to extract trajectory IDs from.
          * @return A list of integers corresponding to all trajectory IDs in the given table.
          */
-        static std::vector<int> db_get_all_trajectory_ids(trajectory_data_handling::db_table table);
+        static std::vector<unsigned int> db_get_all_trajectory_ids(trajectory_data_handling::db_table table);
     private:
         /**
          * The connection string that specifies the connection details for the PostgreSQL database.

--- a/src/trajectory_data_handling/Trajectory_Manager.hpp
+++ b/src/trajectory_data_handling/Trajectory_Manager.hpp
@@ -70,6 +70,13 @@ namespace trajectory_data_handling {
          * Drops all tables and indexes, whereafter it calls create_database to reconstruct the tables.
          */
         static void reset_all_data();
+
+        /**
+         * Extracts all trajectory IDs from the given table.
+         * @param table The database table to extract trajectory IDs from.
+         * @return A list of integers corresponding to all trajectory IDs in the given table.
+         */
+        static std::vector<int> db_get_all_trajectory_ids(trajectory_data_handling::db_table table);
     private:
         /**
          * The connection string that specifies the connection details for the PostgreSQL database.


### PR DESCRIPTION
**Summary of added content:**

- Implements the run method on TRACE-Q, which concurrently runs the TRACE-Q algorithm, utilizing MRPA, in batches corresponding to the maximum number of trajectories that the database connection can handle.
- Implements a new database method, `db_get_all_trajectory_ids`, that fetches all trajectory IDs from a given table.

**Relevant files for review:**

- `src/main.cpp`
- `src/simp-algorithms/MRPA.cpp`
- `src/simp-algorithms/TRACE_Q.cpp`
- `src/simp-algorithms/TRACE_Q.hpp`
- `src/trajectory_data_handling/Trajectory_Manager.cpp`
- `src/trajectory_data_handling/Trajectory_Manager.hpp`


This pull request closes #67